### PR TITLE
Add simple browser shooting game

### DIFF
--- a/shooting_game/index.html
+++ b/shooting_game/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>シンプルシューティング</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="layout">
+      <section class="layout__panel">
+        <header class="layout__header">
+          <h1>シンプルシューティング</h1>
+          <p class="instructions">
+            ← → で移動 / スペースキーでショット<br />
+            敵を倒してスコアを稼ごう！
+          </p>
+          <div class="hud">
+            <div class="hud__item">スコア: <span id="score">0</span></div>
+            <div class="hud__item">ライフ: <span id="lives">3</span></div>
+            <div class="hud__item">ウェーブ: <span id="wave">1</span></div>
+          </div>
+        </header>
+        <canvas id="game" width="480" height="640" role="img" aria-label="シンプルシューティングゲーム"></canvas>
+        <button id="restart" class="restart" hidden>もう一度遊ぶ</button>
+      </section>
+      <aside class="layout__panel layout__panel--info">
+        <h2>遊び方</h2>
+        <ol>
+          <li>← → キーで自機を左右に動かします。</li>
+          <li>スペースキーで弾を発射します。</li>
+          <li>敵に当てるとスコアが増えます。</li>
+          <li>敵や弾に当たるとライフが減ります。ライフがなくなるとゲームオーバーです。</li>
+        </ol>
+        <p>
+          ウェーブが進むごとに敵のスピードが上がり、よりスリリングになります。集中して高スコアを目指しましょう！
+        </p>
+      </aside>
+    </main>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/shooting_game/script.js
+++ b/shooting_game/script.js
@@ -1,0 +1,346 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+
+const scoreEl = document.getElementById('score');
+const livesEl = document.getElementById('lives');
+const waveEl = document.getElementById('wave');
+const restartButton = document.getElementById('restart');
+
+const width = canvas.width;
+const height = canvas.height;
+
+const player = {
+  x: width / 2 - 20,
+  y: height - 70,
+  w: 40,
+  h: 40,
+  speed: 5,
+  cooldown: 0
+};
+
+const state = {
+  running: true,
+  score: 0,
+  lives: 3,
+  wave: 1,
+  enemySpeed: 1.3,
+  enemyShootChance: 0.002
+};
+
+const keys = {
+  left: false,
+  right: false,
+  shoot: false
+};
+
+const bullets = [];
+const enemyBullets = [];
+let enemies = [];
+const stars = Array.from({ length: 80 }, () => ({
+  x: Math.random() * width,
+  y: Math.random() * height,
+  size: Math.random() * 2 + 0.5,
+  speed: Math.random() * 0.6 + 0.2
+}));
+
+function resetGame() {
+  state.running = true;
+  state.score = 0;
+  state.lives = 3;
+  state.wave = 1;
+  state.enemySpeed = 1.3;
+  state.enemyShootChance = 0.002;
+  bullets.length = 0;
+  enemyBullets.length = 0;
+  enemies = [];
+  player.x = width / 2 - player.w / 2;
+  player.cooldown = 0;
+  spawnWave();
+  restartButton.hidden = true;
+}
+
+function spawnWave() {
+  const rows = Math.min(3 + state.wave, 6);
+  const perRow = 6;
+  const padding = 60;
+  const gapX = (width - padding * 2) / (perRow - 1);
+  const gapY = 60;
+
+  for (let row = 0; row < rows; row += 1) {
+    for (let col = 0; col < perRow; col += 1) {
+      enemies.push({
+        x: padding + col * gapX - 20,
+        y: 60 + row * gapY,
+        w: 40,
+        h: 30,
+        vx: (Math.random() * 2 - 1) * 0.6,
+        vy: state.enemySpeed,
+        life: 1
+      });
+    }
+  }
+}
+
+function updateStars(dt) {
+  for (const star of stars) {
+    star.y += star.speed * dt * 60;
+    if (star.y > height) {
+      star.y = -star.size;
+      star.x = Math.random() * width;
+      star.speed = Math.random() * 0.6 + 0.2;
+    }
+  }
+}
+
+function updatePlayer(dt) {
+  if (keys.left) {
+    player.x -= player.speed * dt * 60;
+  }
+  if (keys.right) {
+    player.x += player.speed * dt * 60;
+  }
+  player.x = Math.max(0, Math.min(width - player.w, player.x));
+
+  if (player.cooldown > 0) {
+    player.cooldown -= dt;
+  }
+
+  if (keys.shoot && player.cooldown <= 0) {
+    bullets.push({
+      x: player.x + player.w / 2 - 3,
+      y: player.y,
+      w: 6,
+      h: 12,
+      speed: 9
+    });
+    player.cooldown = 0.3;
+  }
+}
+
+function updateBullets(dt) {
+  for (let i = bullets.length - 1; i >= 0; i -= 1) {
+    const bullet = bullets[i];
+    bullet.y -= bullet.speed * dt * 60;
+    if (bullet.y + bullet.h < 0) {
+      bullets.splice(i, 1);
+      continue;
+    }
+
+    for (let j = enemies.length - 1; j >= 0; j -= 1) {
+      const enemy = enemies[j];
+      if (intersects(bullet, enemy)) {
+        bullets.splice(i, 1);
+        enemy.life -= 1;
+        state.score += 100;
+        if (enemy.life <= 0) {
+          enemies.splice(j, 1);
+        }
+        break;
+      }
+    }
+  }
+}
+
+function updateEnemyBullets(dt) {
+  for (let i = enemyBullets.length - 1; i >= 0; i -= 1) {
+    const bullet = enemyBullets[i];
+    bullet.y += bullet.speed * dt * 60;
+    if (bullet.y > height) {
+      enemyBullets.splice(i, 1);
+      continue;
+    }
+
+    if (intersects(bullet, player)) {
+      enemyBullets.splice(i, 1);
+      damagePlayer();
+    }
+  }
+}
+
+function damagePlayer() {
+  if (!state.running) return;
+  state.lives -= 1;
+  if (state.lives <= 0) {
+    gameOver();
+  }
+}
+
+function gameOver() {
+  state.running = false;
+  restartButton.hidden = false;
+}
+
+function updateEnemies(dt) {
+  const difficultyBoost = 1 + state.wave * 0.1;
+  for (let i = enemies.length - 1; i >= 0; i -= 1) {
+    const enemy = enemies[i];
+    enemy.x += enemy.vx * dt * 60;
+    enemy.y += enemy.vy * dt * 60 * difficultyBoost;
+
+    if (enemy.x < 10 || enemy.x + enemy.w > width - 10) {
+      enemy.vx *= -1;
+    }
+
+    if (enemy.y + enemy.h > height - 80) {
+      enemies.splice(i, 1);
+      damagePlayer();
+      continue;
+    }
+
+    if (Math.random() < state.enemyShootChance * difficultyBoost) {
+      enemyBullets.push({
+        x: enemy.x + enemy.w / 2 - 3,
+        y: enemy.y + enemy.h,
+        w: 6,
+        h: 12,
+        speed: 4 + state.wave * 0.25
+      });
+    }
+  }
+
+  if (enemies.length === 0 && state.running) {
+    state.wave += 1;
+    state.enemySpeed += 0.2;
+    state.enemyShootChance = Math.min(0.01, state.enemyShootChance + 0.0015);
+    spawnWave();
+  }
+}
+
+function intersects(a, b) {
+  return (
+    a.x < b.x + b.w &&
+    a.x + a.w > b.x &&
+    a.y < b.y + b.h &&
+    a.y + a.h > b.y
+  );
+}
+
+function drawBackground() {
+  ctx.fillStyle = '#020617';
+  ctx.fillRect(0, 0, width, height);
+
+  for (const star of stars) {
+    ctx.fillStyle = `rgba(148, 163, 184, ${0.3 + Math.random() * 0.7})`;
+    ctx.beginPath();
+    ctx.arc(star.x, star.y, star.size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function drawPlayer() {
+  ctx.save();
+  ctx.translate(player.x + player.w / 2, player.y + player.h / 2);
+  ctx.fillStyle = '#38bdf8';
+  ctx.beginPath();
+  ctx.moveTo(0, -player.h / 2);
+  ctx.lineTo(player.w / 2, player.h / 2);
+  ctx.lineTo(-player.w / 2, player.h / 2);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawEnemies() {
+  for (const enemy of enemies) {
+    ctx.fillStyle = '#f97316';
+    ctx.beginPath();
+    drawRoundedRect(ctx, enemy.x, enemy.y, enemy.w, enemy.h, 6);
+    ctx.fill();
+    ctx.fillStyle = '#fb7185';
+    ctx.fillRect(enemy.x + 10, enemy.y + 6, enemy.w - 20, 6);
+  }
+}
+
+function drawRoundedRect(context, x, y, width, height, radius) {
+  const r = Math.min(radius, width / 2, height / 2);
+  context.moveTo(x + r, y);
+  context.lineTo(x + width - r, y);
+  context.quadraticCurveTo(x + width, y, x + width, y + r);
+  context.lineTo(x + width, y + height - r);
+  context.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  context.lineTo(x + r, y + height);
+  context.quadraticCurveTo(x, y + height, x, y + height - r);
+  context.lineTo(x, y + r);
+  context.quadraticCurveTo(x, y, x + r, y);
+  context.closePath();
+}
+
+function drawBullets() {
+  ctx.fillStyle = '#f8fafc';
+  for (const bullet of bullets) {
+    ctx.fillRect(bullet.x, bullet.y, bullet.w, bullet.h);
+  }
+
+  ctx.fillStyle = '#f87171';
+  for (const bullet of enemyBullets) {
+    ctx.fillRect(bullet.x, bullet.y, bullet.w, bullet.h);
+  }
+}
+
+function drawGameOver() {
+  if (state.running) return;
+  ctx.fillStyle = 'rgba(2, 6, 23, 0.8)';
+  ctx.fillRect(0, 0, width, height);
+  ctx.fillStyle = '#f8fafc';
+  ctx.font = 'bold 36px "Noto Sans JP", sans-serif';
+  ctx.textAlign = 'center';
+  ctx.fillText('ゲームオーバー', width / 2, height / 2 - 20);
+  ctx.font = '24px "Noto Sans JP", sans-serif';
+  ctx.fillText(`スコア: ${state.score}`, width / 2, height / 2 + 20);
+}
+
+let lastTime = performance.now();
+function loop(now) {
+  const dt = Math.min((now - lastTime) / 1000, 0.033);
+  lastTime = now;
+
+  updateStars(dt);
+
+  if (state.running) {
+    updatePlayer(dt);
+    updateBullets(dt);
+    updateEnemies(dt);
+    updateEnemyBullets(dt);
+  }
+
+  drawBackground();
+  drawPlayer();
+  drawEnemies();
+  drawBullets();
+  drawGameOver();
+
+  scoreEl.textContent = state.score;
+  livesEl.textContent = state.lives;
+  waveEl.textContent = state.wave;
+
+  requestAnimationFrame(loop);
+}
+
+// Input handling
+document.addEventListener('keydown', (event) => {
+  if (event.code === 'ArrowLeft') {
+    keys.left = true;
+    event.preventDefault();
+  } else if (event.code === 'ArrowRight') {
+    keys.right = true;
+    event.preventDefault();
+  } else if (event.code === 'Space') {
+    keys.shoot = true;
+    event.preventDefault();
+  }
+});
+
+document.addEventListener('keyup', (event) => {
+  if (event.code === 'ArrowLeft') {
+    keys.left = false;
+  } else if (event.code === 'ArrowRight') {
+    keys.right = false;
+  } else if (event.code === 'Space') {
+    keys.shoot = false;
+  }
+});
+
+restartButton.addEventListener('click', resetGame);
+
+spawnWave();
+requestAnimationFrame(loop);

--- a/shooting_game/style.css
+++ b/shooting_game/style.css
@@ -1,0 +1,124 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top, #0f172a, #020617 60%);
+  color: #f8fafc;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 1fr minmax(240px, 280px);
+  gap: 24px;
+  width: min(960px, 100%);
+}
+
+.layout__panel {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(8px);
+}
+
+.layout__panel--info {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.layout__header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+h1 {
+  margin: 0;
+  font-size: 28px;
+}
+
+h2 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.instructions {
+  margin: 0;
+  color: #cbd5f5;
+  line-height: 1.5;
+}
+
+.hud {
+  display: flex;
+  gap: 12px;
+  font-weight: 600;
+}
+
+.hud__item {
+  padding: 8px 12px;
+  background: rgba(59, 130, 246, 0.15);
+  border-radius: 8px;
+  border: 1px solid rgba(59, 130, 246, 0.4);
+}
+
+canvas {
+  width: 100%;
+  max-width: 480px;
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(2, 6, 23, 0.95));
+  border: 2px solid rgba(148, 163, 184, 0.25);
+  display: block;
+  margin: 0 auto;
+}
+
+.restart {
+  margin: 16px auto 0;
+  display: block;
+  padding: 12px 24px;
+  border-radius: 999px;
+  border: none;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  color: #0f172a;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.restart:hover,
+.restart:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(99, 102, 241, 0.35);
+}
+
+ol {
+  padding-left: 18px;
+  margin: 0;
+  line-height: 1.6;
+}
+
+p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .layout__panel--info {
+    order: -1;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone HTML page with HUD and instructions for a shooting game
- style the page with a responsive glassmorphism-inspired layout
- implement JavaScript gameplay with player controls, enemy waves, bullets, scoring, and restart flow

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690538894c4c83318f4351e2586bdc66